### PR TITLE
Get repo and owner from github context

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,12 +2,6 @@ name: 'Enforce Single Pull Request Action'
 description: 'Github action that ensure a designated user only has a single PR open at any given time.'
 author: 'Isaiah Moran'
 inputs:
-  owner:
-    required: true
-    description: 'The owner of the repo the action is being performed against.'
-  repo:
-    required: true
-    description: 'The repo the action is being performed against.'
   username:
     required: true
     description: 'The username of the account we want to enforce the one PR only policy on.'

--- a/src/Action.ts
+++ b/src/Action.ts
@@ -24,8 +24,8 @@ export class Action {
 export function createAction(): Action {
   let token = core.getInput("token")
   const git = github.getOctokit(token)
-  let owner = core.getInput("owner")
-  let repo = core.getInput("repo")
+  let owner = github.context.repo.owner
+  let repo = github.context.repo.repo
   let username = core.getInput("username")
   let api = createPullRequestAPI(git, owner, repo)
   return new Action(api, username)


### PR DESCRIPTION
This pulsl the repo and owner from the github context. I'm thinking we can probably just assume you want to run this within the current repo, we can always add these back as inputs later if we find the need to run it elsewhere.

Alternatively, I think there's probably a way to use the `default` syntax within the action.yml for `owner` and `repo` but I didn't have a chance to look up that syntax.